### PR TITLE
Add support for building under MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,3 +39,7 @@ add_subdirectory(lib/ArduinoOcppMongoose)
 target_link_libraries(ao_simulator PUBLIC ArduinoOcppMongoose)
 
 target_link_libraries(ao_simulator PUBLIC ssl crypto)
+
+if(WIN32)
+  target_link_libraries(ao_simulator PUBLIC wsock32 ws2_32)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,4 +42,5 @@ target_link_libraries(ao_simulator PUBLIC ssl crypto)
 
 if(WIN32)
   target_link_libraries(ao_simulator PUBLIC wsock32 ws2_32)
+  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
 endif()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://user-images.githubusercontent.com/63792403/133922028-fefc8abb-fde9-460b-826f-09a458502d17.png" alt="Icon" height="24"> &nbsp; ArduinoOcppSimulator
 
-Tester / Demo App for the [ArduinoOcpp](https://github.com/matth-x/ArduinoOcpp) Client, running on native Ubuntu or the WSL.
+Tester / Demo App for the [ArduinoOcpp](https://github.com/matth-x/ArduinoOcpp) Client, running on native Ubuntu, WSL, or MSYS2.
 
 ![Screenshot](https://github.com/agruenb/arduino-ocpp-dashboard/blob/master/docs/img/status_page.png)
 
@@ -12,7 +12,7 @@ That means that the Simulator runs on your computer and connects to an OCPP serv
 
 ## Installation
 
-On Windows, get the Windows Subsystem for Linux (WSL): [https://ubuntu.com/wsl](https://ubuntu.com/wsl)
+On Windows, get the Windows Subsystem for Linux (WSL): [https://ubuntu.com/wsl](https://ubuntu.com/wsl) or [MSYS2](https://www.msys2.org/).
 
 Then follow the same steps like for Ubuntu.
 

--- a/src/evse.h
+++ b/src/evse.h
@@ -18,7 +18,7 @@ private:
     float simulate_power = 0;
     float limit_power = 11000.f;
     const float SIMULATE_ENERGY_DELTA_MS = SIMULATE_POWER_CONST / (3600.f * 1000.f);
-    ulong simulate_energy_track_time = 0;
+    unsigned long simulate_energy_track_time = 0;
     float simulate_energy = 0;
 
     std::string status;


### PR DESCRIPTION
Add support for building this project under MSYS2.

This appears to work and run under Windows when building under MSYS2. WSL1 is still an option, but appears to be getting less attention from Microsoft now that they have WSL2. While this project will build just fine under WSL2, networking is a bit weird due to the whole Hyper-V situation.

By building natively under Windows (via MSYS2), the program gains native access to the network without needing to run a proxy.