### PR TITLE
Tweak to work with Homebrew OpenSSL on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,12 @@ add_compile_definitions(
 
 add_executable(mo_simulator ${MOCPP_SIM_SRC} ${MOCPP_SIM_MG_SRC})
 
+find_package(OpenSSL REQUIRED)
+
 target_include_directories(mo_simulator PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/lib/ArduinoJson/src"
     "${CMAKE_CURRENT_SOURCE_DIR}/lib/mongoose"
+    "${OPENSSL_INCLUDE_DIR}"
 )
 
 target_compile_definitions(mo_simulator PUBLIC
@@ -51,7 +54,7 @@ target_link_libraries(mo_simulator PUBLIC MicroOcpp)
 add_subdirectory(lib/MicroOcppMongoose)
 target_link_libraries(mo_simulator PUBLIC MicroOcppMongoose)
 
-target_link_libraries(mo_simulator PUBLIC ssl crypto)
+target_link_libraries(mo_simulator PUBLIC ${OPENSSL_LIBRARIES})
 
 # experimental WebAssembly port
 add_executable(mo_simulator_wasm ${MOCPP_SIM_SRC} ${MOCPP_SIM_WASM_SRC})


### PR DESCRIPTION
I had trouble building on macOS as the OpenSSL libraries were not found; I tweaked the CMake configuration to use its `find_package(OpenSSL)` support, which allowed me to build by setting the `OPENSSL_ROOT_DIR` and `OPENSSL_LIBRARIES` properties, like this:

```sh
cmake -S . -B ./build -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -DOPENSSL_LIBRARIES=/usr/local/opt/openssl@1.1/lib
```
I hope this change works OK more generally.