### PR TITLE
Updated Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-# Use Ubuntu as the base image
-FROM ubuntu:latest
+# Use Alpine Linux as the base image
+FROM alpine:latest
 
 # Update package lists and install necessary dependencies
-RUN apt-get update && apt-get install -y \
+RUN apk update && \
+    apk add --no-cache \
     git \
     cmake \
-    libssl-dev \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
+    openssl-dev \
+    build-base
 
 # Set the working directory inside the container
 WORKDIR /MicroOcppSimulator


### PR DESCRIPTION
Hello,

I'm submitting this pull request to suggest a change in the Dockerfile base image. Specifically, I propose switching to a more lightweight option, utilizing Alpine Linux instead of Ubuntu.

In my testing, the resulting image size is significantly reduced as follows:                                    
```
> docker images | grep "microocpp"
microocppsim alpine 58f1ddd1fc03 5 seconds ago 392MB
microocppsim ubuntu 431520d7fc4a 3 minutes ago 659MB  
```
I've thoroughly tested this change, and it functions correctly. (Darwin Kernel Version 23.4.0 arm64, MacOs Sonoma 14.4.1 23E224, docker engine v26.0.0)

By adopting a lighter base image, not only will the final build image be smaller, but also it will likely enhance the efficiency of resource utilization and improve overall performance. This change aligns with best practices for containerization, promoting streamlined deployment and management.

Thank you for considering this enhancement.
