### PR TITLE
Fix EVSE plugged state with legacy dashboard

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -86,9 +86,15 @@ int mocpp_api_call(const char *endpoint, MicroOcpp::Method method, const char *b
         if (method == MicroOcpp::Method::POST) {
             if (request.containsKey("evPlugged")) {
                 evse->setEvPlugged(request["evPlugged"]);
+                // Older dashboard versions only expose one "EV plugged"
+                // control. Keep both cable ends in sync unless the caller
+                // explicitly provides the EVSE-side state.
+                if (!request.containsKey("evsePlugged")) {
+                    evse->setEvsePlugged(request["evPlugged"]);
+                }
             }
             if (request.containsKey("evsePlugged")) {
-            evse->setEvsePlugged(request["evsePlugged"]);
+                evse->setEvsePlugged(request["evsePlugged"]);
             }
             if (request.containsKey("evReady")) {
                 evse->setEvReady(request["evReady"]);


### PR DESCRIPTION
The bundled dashboard sends evPlugged but omits evsePlugged, while the charging simulation requires both states. This change keeps both cable ends synchronized when evsePlugged is omitted, while preserving explicit independent control through the API.